### PR TITLE
Replace deprecated (broken) URI.encode

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,76 @@
+PATH
+  remote: .
+  specs:
+    intrinio-sdk (6.30.0)
+      json (~> 2.1, >= 2.1.0)
+      retriable (~> 3.1, >= 3.1.0)
+      typhoeus (~> 1.0, >= 1.0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ZenTest (4.12.2)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    autotest (4.4.6)
+      ZenTest (>= 4.4.1)
+    autotest-fsevent (0.2.21)
+      sys-uname
+    autotest-growl (0.2.16)
+    autotest-rails-pure (4.1.2)
+    bigdecimal (3.1.8)
+    crack (1.0.0)
+      bigdecimal
+      rexml
+    diff-lcs (1.5.1)
+    ethon (0.16.0)
+      ffi (>= 1.15.0)
+    ffi (1.17.0-arm64-darwin)
+    hashdiff (1.1.1)
+    json (2.7.2)
+    public_suffix (6.0.1)
+    rake (12.0.0)
+    retriable (3.1.2)
+    rexml (3.3.6)
+      strscan
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
+    strscan (3.1.0)
+    sys-uname (1.3.0)
+      ffi (~> 1.1)
+    typhoeus (1.4.1)
+      ethon (>= 0.9.0)
+    vcr (3.0.3)
+    webmock (1.24.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  arm64-darwin
+
+DEPENDENCIES
+  autotest (~> 4.4, >= 4.4.6)
+  autotest-fsevent (~> 0.2, >= 0.2.12)
+  autotest-growl (~> 0.2, >= 0.2.16)
+  autotest-rails-pure (~> 4.1, >= 4.1.2)
+  intrinio-sdk!
+  rake (~> 12.0.0)
+  retriable (~> 3.1)
+  rspec (~> 3.6, >= 3.6.0)
+  vcr (~> 3.0, >= 3.0.1)
+  webmock (~> 1.24, >= 1.24.3)
+
+BUNDLED WITH
+   2.5.16

--- a/lib/intrinio-sdk/api_client.rb
+++ b/lib/intrinio-sdk/api_client.rb
@@ -22,7 +22,7 @@ module Intrinio
   class ApiClient
     # The max number of seconds allowed between each retry interval
     MAX_INTERVAL_SECONDS = 60
-    
+
     # The Configuration object holding settings to be used in the API client.
     attr_accessor :config
 
@@ -55,12 +55,12 @@ module Intrinio
       retry_amount = @config.allow_retries ? 5 : 1
       Retriable.retriable(tries: retry_amount, base_interval: 1.0, multiplier: 1.0, rand_factor: 0.5, max_interval: MAX_INTERVAL_SECONDS) do
         @config.logger.debug("Calling Intrinio API [#{http_method}] - #{path}...") if @config.debugging
-        
+
         request = build_request(http_method, path, opts)
         response = request.run
-        
+
         rate_limit_header = response.headers["retry-after"]
-        
+
         if @config.debugging
           @config.logger.debug "HTTP response body ~BEGIN~\n#{response.body}\n~END~\n"
         end
@@ -70,13 +70,13 @@ module Intrinio
             fail ApiError.new('Connection timed out')
           elsif response.code == 429 && rate_limit_header
             wait_in_seconds = rate_limit_header.to_i
-            
+
             #if the rate limit elapse time header is less than the max allowed interval time, sleep the program until the rate limit period elapses
             if wait_in_seconds < MAX_INTERVAL_SECONDS
               @config.logger.debug "API Rate Limit Reached - Retrying in #{wait_in_seconds} seconds..."
               sleep(wait_in_seconds)
             end
-            
+
             fail ApiError.new(:code => 429,
                               :message => response.return_message)
           elsif response.code.to_s.split("")[0].to_i == 4
@@ -104,7 +104,7 @@ module Intrinio
         end
         return data, response.code, response.headers
       end
-      
+
       # Catch errors that broke out of retry block
       fail non_retriable_error
     end
@@ -296,7 +296,7 @@ module Intrinio
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      URI::DEFAULT_PARSER.escape(@config.base_url + path)
     end
 
     # Builds the HTTP request body

--- a/lib/intrinio-sdk/configuration.rb
+++ b/lib/intrinio-sdk/configuration.rb
@@ -126,7 +126,7 @@ module Intrinio
     attr_accessor :inject_format
 
     attr_accessor :force_ending_format
-    
+
     attr_accessor :allow_retries
 
     def initialize
@@ -178,7 +178,7 @@ module Intrinio
 
     def base_url
       url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      URI::DEFAULT_PARSER.escape(url)
     end
 
     # Gets API key (with prefix if set).


### PR DESCRIPTION
The `URI.encode` method [was deprecated in Ruby version 1.9.2 in 2010](https://ruby-doc.org/3.2.2/NEWS/NEWS-1_9_2.html#label-NEWS+for+Ruby+1.9.2). It's no longer part of the ruby library and therefore this gem is not currently functional.

Alternatives to this approach are approaches like: `URI::Generic.build(scheme: @config.scheme, host: @config.host, path: path).to_s` or
Addressable::URI.encode(url) # (introduces the addressable gem as a dependency)